### PR TITLE
Adjust parser percent conversion and add test

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"bufio"
 	"encoding/json"
+	"math"
 	"os"
 	"path/filepath"
 
@@ -56,12 +57,15 @@ func ParseFile(filePath string, debug bool) ([]model.TimelineEntry, []model.Time
 		}
 
 		rl := logLine.Payload.RateLimits
-		p := int(rl.PrimaryUsedPercent)
-		s := int(rl.SecondaryUsedPercent)
+		primaryRaw := rl.PrimaryUsedPercent
+		secondaryRaw := rl.SecondaryUsedPercent
 
-		if p == 0 && s == 0 {
+		if primaryRaw == 0 && secondaryRaw == 0 {
 			continue
 		}
+
+		p := toDisplayPercent(primaryRaw)
+		s := toDisplayPercent(secondaryRaw)
 
 		total := logLine.Payload.Info.TotalTokenUsage.TotalTokens
 		last := logLine.Payload.Info.LastTokenUsage.TotalTokens
@@ -97,3 +101,9 @@ func ParseFile(filePath string, debug bool) ([]model.TimelineEntry, []model.Time
 	return timelineFull, timelineClean, maxTotal, sumLast, nil
 }
 
+func toDisplayPercent(value float64) int {
+	if value <= 1 {
+		value *= 100
+	}
+	return int(math.Round(value))
+}

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1,0 +1,26 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseFileWithFractionalPrimaryPercent(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "rollout-test.jsonl")
+
+	content := `{"timestamp":"2024-01-01T00:00:00Z","payload":{"info":{"total_token_usage":{"total_tokens":10},"last_token_usage":{"total_tokens":5}},"rate_limits":{"primary_used_percent":0.42,"secondary_used_percent":0.0}}}`
+	if err := os.WriteFile(filePath, []byte(content+"\n"), 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	timelineFull, _, _, _, err := ParseFile(filePath, false)
+	if err != nil {
+		t.Fatalf("ParseFile returned error: %v", err)
+	}
+
+	if len(timelineFull) == 0 {
+		t.Fatalf("expected at least one timeline entry, got 0")
+	}
+}


### PR DESCRIPTION
## Summary
- ensure parser skips entries only when both raw rate limits are zero before converting values
- convert rate limit values to display percentages with rounding and scaling for fractional inputs
- add a parser test covering fractional primary usage values

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68da732025448322a16ed1e5998032d2