### PR TITLE
Handle nested rate limit structure

### DIFF
--- a/internal/model/types.go
+++ b/internal/model/types.go
@@ -2,9 +2,13 @@ package model
 
 // Common structures used across the project (shared by parser and timeline)
 
+type RateLimitDetail struct {
+	UsedPercent float64 `json:"used_percent"`
+}
+
 type RateLimits struct {
-	PrimaryUsedPercent   float64 `json:"primary_used_percent"`
-	SecondaryUsedPercent float64 `json:"secondary_used_percent"`
+	Primary   RateLimitDetail `json:"primary"`
+	Secondary RateLimitDetail `json:"secondary"`
 }
 
 type TokenCount struct {
@@ -31,4 +35,3 @@ type TimelineEntry struct {
 	Primary   int
 	Secondary int
 }
-

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"bufio"
 	"encoding/json"
+	"math"
 	"os"
 	"path/filepath"
 
@@ -56,12 +57,15 @@ func ParseFile(filePath string, debug bool) ([]model.TimelineEntry, []model.Time
 		}
 
 		rl := logLine.Payload.RateLimits
-		p := int(rl.PrimaryUsedPercent)
-		s := int(rl.SecondaryUsedPercent)
+		primaryRaw := rl.Primary.UsedPercent
+		secondaryRaw := rl.Secondary.UsedPercent
 
-		if p == 0 && s == 0 {
+		if primaryRaw == 0 && secondaryRaw == 0 {
 			continue
 		}
+
+		p := toDisplayPercent(primaryRaw)
+		s := toDisplayPercent(secondaryRaw)
 
 		total := logLine.Payload.Info.TotalTokenUsage.TotalTokens
 		last := logLine.Payload.Info.LastTokenUsage.TotalTokens
@@ -97,3 +101,9 @@ func ParseFile(filePath string, debug bool) ([]model.TimelineEntry, []model.Time
 	return timelineFull, timelineClean, maxTotal, sumLast, nil
 }
 
+func toDisplayPercent(value float64) int {
+	if value <= 1 {
+		value *= 100
+	}
+	return int(math.Round(value))
+}

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1,0 +1,54 @@
+package parser
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseFileWithFractionalPrimaryPercent(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "rollout-test.jsonl")
+
+	content := `{"timestamp":"2024-01-01T00:00:00Z","payload":{"info":{"total_token_usage":{"total_tokens":10},"last_token_usage":{"total_tokens":5}},"rate_limits":{"primary":{"used_percent":0.42},"secondary":{"used_percent":0.0}}}}`
+	if err := os.WriteFile(filePath, []byte(content+"\n"), 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	timelineFull, _, _, _, err := ParseFile(filePath, false)
+	if err != nil {
+		t.Fatalf("ParseFile returned error: %v", err)
+	}
+
+	if len(timelineFull) == 0 {
+		t.Fatalf("expected at least one timeline entry, got 0")
+	}
+}
+
+func TestParseFileWithNestedRateLimitStructure(t *testing.T) {
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "rollout-nested.jsonl")
+
+	content := `{"timestamp":"2025-09-29T04:16:49.337Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"total_tokens":10},"last_token_usage":{"total_tokens":5}},"rate_limits":{"primary":{"used_percent":6.0},"secondary":{"used_percent":100.0}}}}`
+	if err := os.WriteFile(filePath, []byte(content+"\n"), 0644); err != nil {
+		t.Fatalf("failed to write test file: %v", err)
+	}
+
+	timelineFull, _, _, _, err := ParseFile(filePath, false)
+	if err != nil {
+		t.Fatalf("ParseFile returned error: %v", err)
+	}
+
+	if len(timelineFull) != 1 {
+		t.Fatalf("expected exactly one timeline entry, got %d", len(timelineFull))
+	}
+
+	entry := timelineFull[0]
+	if entry.Primary != 6 {
+		t.Fatalf("expected primary to be 6, got %d", entry.Primary)
+	}
+
+	if entry.Secondary != 100 {
+		t.Fatalf("expected secondary to be 100, got %d", entry.Secondary)
+	}
+}


### PR DESCRIPTION
## Summary
- update the rate limit model to match the nested primary/secondary payload schema
- read nested rate limit percentages before converting to display values in the parser
- extend parser tests to cover both fractional and nested rate limit samples

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68da732025448322a16ed1e5998032d2